### PR TITLE
feat(ENG-10837): add sdk version to headers

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,15 @@ else
   yarn install --frozen-lockfile
 fi
 
+# ENG-10837: injects the real package version into the Fern-generated client so the
+# emitted headers match the published release instead of the 0.0.1 placeholder.
+# Done here (build time) rather than in `Client.ts` so Fern can own it and keep
+# tracking new API resources on regeneration.
+SDK_VERSION=$(node -p "require('../package.json').version")
+echo "Stamping SDK version ${SDK_VERSION} into src/Client.ts"
+sed -i -E "s#(\"X-Fern-SDK-Version\": \")[^\"]*(\")#\1${SDK_VERSION}\2#" ../src/Client.ts
+sed -i -E "s#(\"User-Agent\": \"@basis-theory/node-sdk/)[^\"]*(\")#\1${SDK_VERSION}\2#" ../src/Client.ts
+
 yarn build
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,10 +16,34 @@ fi
 # emitted headers match the published release instead of the 0.0.1 placeholder.
 # Done here (build time) rather than in `Client.ts` so Fern can own it and keep
 # tracking new API resources on regeneration.
+CLIENT_FILE="../src/Client.ts"
 SDK_VERSION=$(node -p "require('../package.json').version")
+
+# Fail closed on a non-semver version. SDK_VERSION is interpolated into the sed
+# replacement below; restricting it to semver characters keeps sed metacharacters
+# (#, &, \1) and GNU sed's `e` flag out of an OIDC-backed release job.
+if [[ ! "$SDK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "ERROR: invalid SDK version '${SDK_VERSION}'; expected semver (e.g. 1.2.3)" >&2
+  exit 1
+fi
+
 echo "Stamping SDK version ${SDK_VERSION} into src/Client.ts"
-sed -i -E "s#(\"X-Fern-SDK-Version\": \")[^\"]*(\")#\1${SDK_VERSION}\2#" ../src/Client.ts
-sed -i -E "s#(\"User-Agent\": \"@basis-theory/node-sdk/)[^\"]*(\")#\1${SDK_VERSION}\2#" ../src/Client.ts
+
+# Replace one header value, failing loudly if the expected pattern is absent.
+# sed exits 0 even when nothing matches, so without this guard a Fern change to the
+# generated header would silently publish the stale 0.0.1 placeholder.
+stamp_header() {
+  local pattern="$1"
+  if ! grep -qE "$pattern" "$CLIENT_FILE"; then
+    echo "ERROR: pattern not found in ${CLIENT_FILE}: ${pattern}" >&2
+    echo "Fern may have changed the generated client; update scripts/build.sh." >&2
+    exit 1
+  fi
+  sed -i -E "s#${pattern}#\1${SDK_VERSION}\2#" "$CLIENT_FILE"
+}
+
+stamp_header "(\"X-Fern-SDK-Version\": \")[^\"]*(\")"
+stamp_header "(\"User-Agent\": \"@basis-theory/node-sdk/)[^\"]*(\")"
 
 yarn build
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Stamp the real package version into the Fern-generated `src/Client.ts` at **build time** in `scripts/build.sh`, updating `X-Fern-SDK-Version` and `User-Agent` from the `0.0.1` placeholder to match `package.json.version`.
- `package.json` is already bumped from the release tag / deploy-dev workflow **before** `build.sh` runs, so published artifacts emit headers like `@basis-theory/node-sdk/<release-version>` instead of `@basis-theory/node-sdk/0.0.1`.
- `src/Client.ts` remains fully Fern-owned (not added to `.fernignore`) so future API regenerations continue to add new resource clients without going stale.

Closes [ENG-10837](https://linear.app/basis-theory/issue/ENG-10837/whitelist-fern-sdk-metadata-headers-and-align-node-sdk-user-agent) (node-sdk portion).

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back