### PR TITLE
fix(eng-10837): use node to stamp package version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,27 +27,10 @@ if [[ ! "$SDK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
   exit 1
 fi
 
-echo "Stamping SDK version ${SDK_VERSION} into src/Client.ts"
-
-# Replace one header value, failing loudly if the expected pattern is absent.
-# sed exits 0 even when nothing matches, so without this guard a Fern change to the
-# generated header would silently publish the stale 0.0.1 placeholder.
-stamp_header() {
-  local pattern="$1"
-  if ! grep -qE "$pattern" "$CLIENT_FILE"; then
-    echo "ERROR: pattern not found in ${CLIENT_FILE}: ${pattern}" >&2
-    echo "Fern may have changed the generated client; update scripts/build.sh." >&2
-    exit 1
-  fi
-  sed -i -E "s#${pattern}#\1${SDK_VERSION}\2#" "$CLIENT_FILE"
-}
-
-stamp_header "(\"X-Fern-SDK-Version\": \")[^\"]*(\")"
-stamp_header "(\"User-Agent\": \"@basis-theory/node-sdk/)[^\"]*(\")"
+echo "Stamping SDK version ${SDK_VERSION} into ${CLIENT_FILE}"
+node ./stamp-sdk-version.js "$CLIENT_FILE" "$SDK_VERSION"
 
 yarn build
-
-
 
 cd "$current_directory"
 

--- a/scripts/stamp-sdk-version.js
+++ b/scripts/stamp-sdk-version.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+
+const [clientFile, version] = process.argv.slice(2);
+
+if (!clientFile || !version) {
+    console.error("Usage: stamp-sdk-version.js <client-file> <version>");
+    process.exit(1);
+}
+
+const stamps = [
+    [/("X-Fern-SDK-Version": ")[^"]*(")/, "X-Fern-SDK-Version"],
+    [/("User-Agent": "@basis-theory\/node-sdk\/)[^"]*(")/, "User-Agent"],
+];
+
+let content = fs.readFileSync(clientFile, "utf8");
+
+for (const [pattern, label] of stamps) {
+    if (!pattern.test(content)) {
+        console.error(`ERROR: pattern not found for ${label} in ${clientFile}`);
+        console.error("Fern may have changed the generated client; update scripts/stamp-sdk-version.js.");
+        process.exit(1);
+    }
+    content = content.replace(pattern, `$1${version}$2`);
+}
+
+fs.writeFileSync(clientFile, content);


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Follow up fix for https://linear.app/basis-theory/issue/ENG-10837/whitelist-fern-sdk-metadata-headers-and-align-node-sdk-user-agent.
- I noticed the package was not tagged properly during last release, due to a `sed` behavior when the string starts with an integer (which is the case for our releases: 6.0.0)


<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

