### PR TITLE
fix: handle updated Google Pay error message in canary test

### DIFF
--- a/tests/integration/canary.test.ts
+++ b/tests/integration/canary.test.ts
@@ -690,13 +690,18 @@ describe('google pay', () => {
 
         const jsonObject = JSON.parse(jsonString);
 
+        expect.assertions(2);
         try {
             await client.googlePay.create({
                 googlePaymentData: jsonObject
             });
         } catch (err) {
             expect(err).toBeInstanceOf(UnprocessableEntityError);
-            expect((err as any).body.detail).toContain('Failed to decrypt Google payment request');
+            // The API returns either the legacy "decrypt" wording or the newer
+            // "process ... invalid or malformed" wording for an expired signing key.
+            expect((err as any).body.detail).toMatch(
+                /Failed to (decrypt Google payment request|process the Google Pay token)/
+            );
         }
     });
 });


### PR DESCRIPTION
## Description
- The `google pay › should call; Expect signing key expired error` canary test asserted on the exact API error string `Failed to decrypt Google payment request`. The dev API now returns `Failed to process the Google Pay token; the token payload is invalid or malformed.` for the expired-signing-key payload, failing the test on every PR.
- Loosen the assertion to `toMatch` either the legacy or new wording.
- Add `expect.assertions(2)` so the canary fails loudly if the call ever stops throwing (previously the `try/catch` would pass silently with no error).

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
N/A

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change