### PR TITLE
fix(ENG-11602): pin npm to 11.18.0 for OIDC trusted publishing on Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           # registry-url is intentionally NOT set - it creates .npmrc that blocks OIDC
 
       - name: Update npm for Trusted Publishing
-        run: npm install -g npm@latest # Requires npm 10.5.1+ for OIDC support
+        run: npm install -g npm@11.18.0 # npm 11.x — last line supporting Node 20; OIDC trusted publishing needs >= 11.5.1
 
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## Description

- The `Release` workflow (`release.yml`) fails at **"Update npm for Trusted Publishing"** (`npm install -g npm@latest`), blocking every prod npm publish of `@basis-theory/node-sdk`.
- Root cause: `npm@latest` rolled forward to **npm@12.0.1**, which dropped Node 20 support (requires node `^22.22.2 || ^24.15.0 || >=26.0.0`). The release job pins Node 20, so the global install is rejected with `EBADENGINE`.
- Fix: pin to **npm@11.18.0** — the last npm 11.x release. It supports Node `^20.17.0 || >=22.9.0` (keeps Node 20) and satisfies OIDC trusted publishing (needs ≥ 11.5.1). Exact-pinning also stops a future `@latest` major from silently breaking releases again.
- Also corrected the stale inline comment (OIDC support landed in npm 11.5.1, not 10.5.1).
- Matches the fix already shipped for the Elements repo in ENG-11595 (PRs #684/#685).

## Business Impact

Unblocks all production npm releases of `@basis-theory/node-sdk`, which are currently failing on every run.

## Testing

- Verified `npm@11.18.0` engines are `^20.17.0 || >=22.9.0` (supports the pinned Node 20) via `npm view npm@11.18.0 engines`.
- Confirmed `11.18.0` is the latest 11.x (`next-11` dist-tag) and that `12.0.1` is what dropped Node 20.
- Single-line workflow change; will confirm the "Update npm for Trusted Publishing" step succeeds and a release completes end-to-end on the next tagged release.

## Screenshots

N/A — CI workflow change.

## Rollback

Revert this commit. The step returns to `npm install -g npm@latest` (currently broken).

## Documentation

N/A.

## Reviewer Checklist

- [ ] Change is limited to pinning the npm version in `release.yml`
- [ ] Pinned npm (11.18.0) supports Node 20 and OIDC trusted publishing (≥ 11.5.1)
- [ ] No other workflow installs `npm@latest` for OIDC publishing

Closes ENG-11602. Related: ENG-11595.